### PR TITLE
Handle APNG chunks

### DIFF
--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -884,3 +884,4 @@ Image.register_save(PngImageFile.format, _save)
 Image.register_extensions(PngImageFile.format, [".png", ".apng"])
 
 Image.register_mime(PngImageFile.format, "image/png")
+Image.register_mime(PngImageFile.format, "image/apng")

--- a/src/PIL/PngImagePlugin.py
+++ b/src/PIL/PngImagePlugin.py
@@ -526,6 +526,19 @@ class PngStream(ChunkStream):
 
         return s
 
+    # APNG chunks
+    def chunk_acTL(self, pos, length):
+        s = ImageFile._safe_read(self.fp, length)
+        return s
+
+    def chunk_fcTL(self, pos, length):
+        s = ImageFile._safe_read(self.fp, length)
+        return s
+
+    def chunk_fdAT(self, pos, length):
+        s = ImageFile._safe_read(self.fp, length)
+        return s
+
 
 # --------------------------------------------------------------------
 # PNG reader


### PR DESCRIPTION
* Add image/apng mime type
* Handle APNG chunks, which was causing tests to fail
* Change the test to check that the image is similar to the original